### PR TITLE
[TS] API再エクスポート: parseEntitiesCsv / Entity

### DIFF
--- a/packages/engine-ts/src/index.ts
+++ b/packages/engine-ts/src/index.ts
@@ -138,3 +138,6 @@ export function deserialize(payload: string): SessionState {
   const parsed = JSON.parse(payload)
   return parsed as SessionState
 }
+
+export type { Entity } from './entities'
+export { parseEntitiesCsv } from './entities'


### PR DESCRIPTION
packages/engine-ts のエントリポイントに API を再エクスポートしました。
- export type { Entity } from './entities'
- export { parseEntitiesCsv } from './entities'

影響: 外部パッケージから正式に利用可能になります。
AC: ビルド/テスト通過。
closes #8