### PR TITLE
[Unity] Entity型の整備と Controller リファクタ

### DIFF
--- a/packages/engine-ts/src/index.ts
+++ b/packages/engine-ts/src/index.ts
@@ -138,3 +138,6 @@ export function deserialize(payload: string): SessionState {
   const parsed = JSON.parse(payload)
   return parsed as SessionState
 }
+
+export type { Entity } from './entities'
+export { parseEntitiesCsv } from './entities'

--- a/packages/sdk-unity/Runtime/Entity.cs
+++ b/packages/sdk-unity/Runtime/Entity.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace VastCore.NarrativeGen
+{
+    [Serializable]
+    public class Entity
+    {
+        public string Id = string.Empty;
+        public string Brand = string.Empty;
+        public string Description = string.Empty;
+    }
+}

--- a/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
+++ b/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
@@ -25,8 +25,8 @@ namespace VastCore.NarrativeGen
                 var map = ParseEntitiesCsv(EntitiesCsv.text);
                 if (map.TryGetValue(TargetId, out var ent))
                 {
-                    Debug.Log($"[MinimalNarrativeController] Entity '{TargetId}' brand: {ent.brand}");
-                    Debug.Log($"[MinimalNarrativeController] Entity '{TargetId}' description: {ent.description}");
+                    Debug.Log($"[MinimalNarrativeController] Entity '{TargetId}' brand: {ent.Brand}");
+                    Debug.Log($"[MinimalNarrativeController] Entity '{TargetId}' description: {ent.Description}");
                 }
                 else
                 {
@@ -39,9 +39,9 @@ namespace VastCore.NarrativeGen
             }
         }
 
-        private static Dictionary<string, (string brand, string description)> ParseEntitiesCsv(string csv)
+        private static Dictionary<string, Entity> ParseEntitiesCsv(string csv)
         {
-            var result = new Dictionary<string, (string brand, string description)>();
+            var result = new Dictionary<string, Entity>();
             if (string.IsNullOrWhiteSpace(csv)) return result;
 
             var lines = csv.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
@@ -70,7 +70,7 @@ namespace VastCore.NarrativeGen
                 if (string.IsNullOrEmpty(id)) continue;
                 string brand = SafeGet(row, colIndex["brand"]).Trim();
                 string description = SafeGet(row, colIndex["description"]).Trim();
-                result[id] = (brand, description);
+                result[id] = new Entity { Id = id, Brand = brand, Description = description };
             }
             return result;
         }


### PR DESCRIPTION
packages/sdk-unity に Entity クラスを追加し、MinimalNarrativeController が Dictionary<string, Entity> を用いて型安全に扱うようにしました。
- 追加: Runtime/Entity.cs
- 変更: Runtime/MinimalNarrativeController.cs（ログ参照を Brand/Description に変更）

AC: ビルド可能、ログ出力が Entity のプロパティを参照。
closes #9