### PR TITLE
[UPM] Minimal sample package support

### DIFF
--- a/packages/sdk-unity/Editor/SamplesMenu.cs
+++ b/packages/sdk-unity/Editor/SamplesMenu.cs
@@ -1,0 +1,64 @@
+#if UNITY_EDITOR
+using System.IO;
+using System.Text;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace VastCore.NarrativeGen.Editor
+{
+    public static class SamplesMenu
+    {
+        private const string SamplesRoot = "Assets/NarrativeGenSamples";
+        private const string CsvPath = SamplesRoot + "/Entities.csv";
+        private const string ScenePath = SamplesRoot + "/MinimalSample.unity";
+
+        [MenuItem("NarrativeGen/Create Minimal Sample Scene")]
+        public static void CreateMinimalSampleScene()
+        {
+            EnsureFolders();
+            CreateCsvIfMissing();
+
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects, NewSceneMode.Single);
+            scene.name = "MinimalSample";
+
+            var go = new GameObject("NarrativeGenController");
+            var ctrl = go.AddComponent<VastCore.NarrativeGen.MinimalNarrativeController>();
+
+            var csvAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(CsvPath);
+            if (csvAsset == null)
+            {
+                Debug.LogWarning($"[Samples] CSV asset not found at {CsvPath}. Creating a new one.");
+                CreateCsvIfMissing();
+                csvAsset = AssetDatabase.LoadAssetAtPath<TextAsset>(CsvPath);
+            }
+            ctrl.EntitiesCsv = csvAsset;
+            ctrl.TargetId = "mac_burger_001";
+
+            EditorSceneManager.SaveScene(scene, ScenePath);
+            AssetDatabase.Refresh();
+            EditorGUIUtility.PingObject(AssetDatabase.LoadAssetAtPath<SceneAsset>(ScenePath));
+            Debug.Log("[Samples] Minimal sample scene created at: " + ScenePath);
+        }
+
+        private static void EnsureFolders()
+        {
+            if (!AssetDatabase.IsValidFolder("Assets/NarrativeGenSamples"))
+            {
+                AssetDatabase.CreateFolder("Assets", "NarrativeGenSamples");
+            }
+        }
+
+        private static void CreateCsvIfMissing()
+        {
+            if (!File.Exists(CsvPath))
+            {
+                var csv = "id,brand,description\nmac_burger_001,MacBurger,これはおいしいチーズバーガーです\n";
+                File.WriteAllText(CsvPath, csv, Encoding.UTF8);
+                AssetDatabase.ImportAsset(CsvPath);
+            }
+        }
+    }
+}
+#endif

--- a/packages/sdk-unity/Samples~/Minimal/README.md
+++ b/packages/sdk-unity/Samples~/Minimal/README.md
@@ -1,0 +1,14 @@
+# NarrativeGen Minimal Sample
+
+このサンプルは `MinimalNarrativeController` の動作を確認するための最小構成です。
+
+## 使い方
+1. Unity メニューから次を実行:
+   - `NarrativeGen > Create Minimal Sample Scene`
+2. `Assets/NarrativeGenSamples/MinimalSample.unity` が生成されます。
+3. シーンを開き、再生すると Console に以下が出力されます:
+   - brand: `MacBurger`
+   - description: `これはおいしいチーズバーガーです`
+
+補足: メニュー実行時に `Assets/NarrativeGenSamples/Entities.csv` も生成され、
+`MinimalNarrativeController` の `EntitiesCsv` に自動で割り当てられます。

--- a/packages/sdk-unity/package.json
+++ b/packages/sdk-unity/package.json
@@ -9,5 +9,12 @@
   },
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "3.2.1"
-  }
+  },
+  "samples": [
+    {
+      "displayName": "Minimal",
+      "description": "Minimal sample with a controller that logs an entity's brand and description.",
+      "path": "Samples~/Minimal"
+    }
+  ]
 }


### PR DESCRIPTION
Samples~ に Minimal サンプルと README を追加し、NarrativeGen メニューからシーンを生成できる Editor メニューを提供します。
- Packages: package.json に samples 定義を追加
- Editor: SamplesMenu.cs でシーン/CSV を生成
- Samples~: Minimal/README.md を追加

closes #10