### PR TITLE
Unity SDK choice outcome support

### DIFF
--- a/packages/sdk-unity/NarrativeGen.Unity.csproj
+++ b/packages/sdk-unity/NarrativeGen.Unity.csproj
@@ -9,7 +9,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="Runtime\**\*.cs" />
+    <Compile Include="Runtime\**\*.cs" Exclude="Runtime\MinimalNarrativeController.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/packages/sdk-unity/Runtime/Engine.cs
+++ b/packages/sdk-unity/Runtime/Engine.cs
@@ -69,8 +69,8 @@ namespace VastCore.NarrativeGen
                 target = node.Id; // stay if no target specified
             if (!model.Nodes.ContainsKey(target))
                 throw new ArgumentException($"Target node '{target}' not found in model");
-
-            return session.With(currentNodeId: target, flags: flags, resources: resources);
+            var nextTime = session.Time + 1;
+            return session.With(currentNodeId: target, flags: flags, resources: resources, time: nextTime);
         }
 
         private static bool EvaluateConditions(List<Condition>? conditions, Runtime.Session session)

--- a/packages/sdk-unity/Runtime/GameSession.cs
+++ b/packages/sdk-unity/Runtime/GameSession.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VastCore.NarrativeGen.Runtime;
+
+namespace VastCore.NarrativeGen
+{
+    public class GameSession
+    {
+        private readonly NarrativeModel _model;
+        private Session _session;
+        private readonly Dictionary<string, Entity> _entityMap;
+        private readonly List<string> _inventory;
+        private readonly Dictionary<string, ChoiceOutcome> _choiceOutcomes;
+        private ChoiceOutcome? _lastOutcome;
+
+        public GameSession(
+            NarrativeModel model,
+            IEnumerable<Entity>? entities = null,
+            IEnumerable<string>? initialInventory = null,
+            IDictionary<string, ChoiceOutcome>? choiceOutcomes = null,
+            Session? initialState = null)
+        {
+            _model = model ?? throw new ArgumentNullException(nameof(model));
+            _session = initialState ?? Engine.StartSession(model);
+
+            _entityMap = new Dictionary<string, Entity>(StringComparer.OrdinalIgnoreCase);
+            if (entities != null)
+            {
+                foreach (var entity in entities)
+                {
+                    if (entity == null || string.IsNullOrWhiteSpace(entity.Id)) continue;
+                    _entityMap[entity.Id] = entity;
+                }
+            }
+
+            _inventory = new List<string>();
+            if (initialInventory != null)
+            {
+                foreach (var id in initialInventory)
+                {
+                    AddInventoryItem(id);
+                }
+            }
+
+            _choiceOutcomes = choiceOutcomes != null
+                ? new Dictionary<string, ChoiceOutcome>(choiceOutcomes, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, ChoiceOutcome>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Session State => _session;
+
+        public ChoiceOutcome? LastOutcome => _lastOutcome;
+
+        public IReadOnlyList<Entity> ListInventory()
+        {
+            var items = new List<Entity>();
+            foreach (var id in _inventory)
+            {
+                if (_entityMap.TryGetValue(id, out var entity))
+                {
+                    items.Add(entity);
+                }
+            }
+            return items;
+        }
+
+        public Entity? PickupEntity(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id)) return null;
+            if (!_entityMap.TryGetValue(id, out var entity)) return null;
+            AddInventoryItem(id);
+            return entity;
+        }
+
+        public Entity? RemoveEntity(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id)) return null;
+            if (!_entityMap.TryGetValue(id, out var entity)) return null;
+            RemoveInventoryItem(id);
+            return entity;
+        }
+
+        public IReadOnlyList<Choice> GetAvailableChoices()
+        {
+            var choices = Engine.GetAvailableChoices(_session, _model);
+            return choices
+                .Select(choice => CloneChoiceWithOutcome(choice, ResolveOutcome(choice.Id)))
+                .ToList();
+        }
+
+        public Session ApplyChoice(string choiceId)
+        {
+            if (string.IsNullOrWhiteSpace(choiceId))
+                throw new ArgumentException("choiceId is required", nameof(choiceId));
+
+            _session = Engine.ApplyChoice(_session, _model, choiceId);
+            var outcome = ResolveOutcome(choiceId);
+            ApplyOutcome(outcome);
+            _lastOutcome = outcome;
+            return _session;
+        }
+
+        private ChoiceOutcome? ResolveOutcome(string choiceId)
+        {
+            if (_choiceOutcomes.TryGetValue(choiceId, out var outcome))
+            {
+                return outcome;
+            }
+
+            var choice = FindChoiceInModel(choiceId);
+            return choice?.Outcome;
+        }
+
+        private Choice? FindChoiceInModel(string choiceId)
+        {
+            foreach (var node in _model.Nodes.Values)
+            {
+                if (node.Choices == null) continue;
+                var match = node.Choices.FirstOrDefault(c => string.Equals(c.Id, choiceId, StringComparison.OrdinalIgnoreCase));
+                if (match != null) return match;
+            }
+
+            return null;
+        }
+
+        private void ApplyOutcome(ChoiceOutcome? outcome)
+        {
+            if (outcome == null || string.IsNullOrWhiteSpace(outcome.Type)) return;
+
+            switch (outcome.Type.ToUpperInvariant())
+            {
+                case "ADD_ITEM":
+                    AddInventoryItem(outcome.Value);
+                    break;
+                case "REMOVE_ITEM":
+                    RemoveInventoryItem(outcome.Value);
+                    break;
+                case "NONE":
+                case "":
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void AddInventoryItem(string? id)
+        {
+            if (string.IsNullOrWhiteSpace(id)) return;
+            if (!_entityMap.ContainsKey(id)) return;
+            if (_inventory.Contains(id)) return;
+            _inventory.Add(id);
+        }
+
+        private void RemoveInventoryItem(string? id)
+        {
+            if (string.IsNullOrWhiteSpace(id)) return;
+            _inventory.Remove(id);
+        }
+
+        private static Choice CloneChoiceWithOutcome(Choice source, ChoiceOutcome? outcome)
+        {
+            return new Choice
+            {
+                Id = source.Id,
+                Text = source.Text,
+                Target = source.Target,
+                Conditions = source.Conditions,
+                Effects = source.Effects,
+                Outcome = outcome
+            };
+        }
+    }
+}

--- a/packages/sdk-unity/Runtime/Model.cs
+++ b/packages/sdk-unity/Runtime/Model.cs
@@ -62,6 +62,7 @@ namespace VastCore.NarrativeGen
         [JsonProperty("target")] public string? Target { get; set; }
         [JsonProperty("conditions")] public List<Condition>? Conditions { get; set; }
         [JsonProperty("effects")] public List<Effect>? Effects { get; set; }
+        [JsonProperty("outcome")] public ChoiceOutcome? Outcome { get; set; }
 
         public void Validate()
         {
@@ -70,6 +71,12 @@ namespace VastCore.NarrativeGen
             if (string.IsNullOrWhiteSpace(Text))
                 throw new ArgumentException("Choice.text is required");
         }
+    }
+
+    public class ChoiceOutcome
+    {
+        [JsonProperty("type")] public string Type { get; set; } = string.Empty;
+        [JsonProperty("value")] public string Value { get; set; } = string.Empty;
     }
 
     // Conditions

--- a/packages/tests/NarrativeGen.Tests/GameSessionChoicesTests.cs
+++ b/packages/tests/NarrativeGen.Tests/GameSessionChoicesTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using VastCore.NarrativeGen;
+using VastCore.NarrativeGen.Runtime;
+
+namespace NarrativeGen.Tests
+{
+    [TestFixture]
+    public class GameSessionChoicesTests
+    {
+        private static NarrativeModel CreateModel()
+        {
+            return new NarrativeModel
+            {
+                StartNode = "hub",
+                Nodes = new Dictionary<string, Node>
+                {
+                    ["hub"] = new Node
+                    {
+                        Id = "hub",
+                        Choices = new List<Choice>
+                        {
+                            new Choice
+                            {
+                                Id = "choose_burger",
+                                Text = "チーズバーガーを食べる",
+                                Target = "hub",
+                                Outcome = new ChoiceOutcome { Type = "ADD_ITEM", Value = "mac_burger_001" }
+                            },
+                            new Choice
+                            {
+                                Id = "choose_coffee",
+                                Text = "コーヒーを飲む",
+                                Target = "hub",
+                                Outcome = new ChoiceOutcome { Type = "ADD_ITEM", Value = "coffee_001" }
+                            },
+                            new Choice
+                            {
+                                Id = "discard",
+                                Text = "アイテムを捨てる",
+                                Target = "hub",
+                                Outcome = new ChoiceOutcome { Type = "REMOVE_ITEM", Value = "mac_burger_001" }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        private static List<Entity> CreateEntities() => new()
+        {
+            new Entity { Id = "mac_burger_001", Brand = "MacBurger", Description = "おいしいバーガー", Cost = 100 },
+            new Entity { Id = "coffee_001", Brand = "CoffeeStand", Description = "香り高いコーヒー", Cost = 50 },
+        };
+
+        [Test]
+        public void ApplyChoice_AddsItemToInventory()
+        {
+            var model = CreateModel();
+            var session = new GameSession(model, entities: CreateEntities());
+
+            var choices = session.GetAvailableChoices();
+            Assert.That(choices, Has.Count.EqualTo(3));
+            Assert.That(choices[0].Outcome, Is.Not.Null);
+
+            var result = session.ApplyChoice("choose_burger");
+            Assert.That(result.Time, Is.EqualTo(1));
+
+            var inventory = session.ListInventory();
+            Assert.That(inventory, Has.Count.EqualTo(1));
+            Assert.That(inventory[0].Id, Is.EqualTo("mac_burger_001"));
+            Assert.That(session.LastOutcome, Is.Not.Null);
+            Assert.That(session.LastOutcome!.Type, Is.EqualTo("ADD_ITEM"));
+        }
+
+        [Test]
+        public void ApplyChoice_RemoveItemFromInventory()
+        {
+            var model = CreateModel();
+            var session = new GameSession(
+                model,
+                entities: CreateEntities(),
+                initialInventory: new[] { "mac_burger_001" }
+            );
+
+            var result = session.ApplyChoice("discard");
+            Assert.That(result.Time, Is.EqualTo(1));
+
+            var inventory = session.ListInventory();
+            Assert.That(inventory, Is.Empty);
+            Assert.That(session.LastOutcome, Is.Not.Null);
+            Assert.That(session.LastOutcome!.Type, Is.EqualTo("REMOVE_ITEM"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mirror ChoiceOutcome model from TypeScript engine into Unity SDK
- add C# GameSession with choice listing and apply logic plus inventory outcomes
- add NUnit tests validating choice apply updates inventory and last outcome

## Testing
- dotnet test Packages/tests/NarrativeGen.Tests/NarrativeGen.Tests.csproj
