### PR TITLE
Fix TextMeshPro reference in Unity SDK

### DIFF
--- a/packages/sdk-unity/Editor/SamplesMenu.cs
+++ b/packages/sdk-unity/Editor/SamplesMenu.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using TMPro;
 
 namespace VastCore.NarrativeGen.Editor
 {
@@ -116,17 +117,16 @@ namespace VastCore.NarrativeGen.Editor
             return rect;
         }
 
-        private static Text CreateStatusText(Transform parent)
+        private static TextMeshProUGUI CreateStatusText(Transform parent)
         {
-            var textGo = new GameObject("StatusText", typeof(RectTransform), typeof(Text));
+            var textGo = new GameObject("StatusText", typeof(RectTransform), typeof(TextMeshProUGUI));
             var rect = textGo.GetComponent<RectTransform>();
             rect.SetParent(parent, false);
             rect.sizeDelta = new Vector2(0f, 60f);
 
-            var text = textGo.GetComponent<Text>();
-            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-            text.fontSize = 20;
-            text.alignment = TextAnchor.MiddleCenter;
+            var text = textGo.GetComponent<TextMeshProUGUI>();
+            text.fontSize = 24;
+            text.alignment = TextAlignmentOptions.Midline;
             text.color = Color.white;
             text.text = "状態: 初期化待ち";
 
@@ -146,7 +146,7 @@ namespace VastCore.NarrativeGen.Editor
             var layout = buttonGo.GetComponent<LayoutElement>();
             layout.minHeight = 48f;
 
-            var textGo = new GameObject("Text", typeof(RectTransform), typeof(Text));
+            var textGo = new GameObject("Text", typeof(RectTransform), typeof(TextMeshProUGUI));
             var textRect = textGo.GetComponent<RectTransform>();
             textRect.SetParent(buttonGo.transform, false);
             textRect.anchorMin = Vector2.zero;
@@ -154,10 +154,9 @@ namespace VastCore.NarrativeGen.Editor
             textRect.offsetMin = Vector2.zero;
             textRect.offsetMax = Vector2.zero;
 
-            var text = textGo.GetComponent<Text>();
-            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-            text.fontSize = 18;
-            text.alignment = TextAnchor.MiddleCenter;
+            var text = textGo.GetComponent<TextMeshProUGUI>();
+            text.fontSize = 20;
+            text.alignment = TextAlignmentOptions.Center;
             text.color = Color.white;
             text.text = "選択肢";
 

--- a/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
+++ b/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
@@ -20,7 +20,7 @@ namespace VastCore.NarrativeGen
         public Button ChoiceButtonPrefab;
 
         [Tooltip("Text element showing current session status")]
-        public Text StatusText;
+        public TextMeshProUGUI StatusText;
 
         private GameSession? _session;
         private NarrativeModel? _model;
@@ -88,7 +88,7 @@ namespace VastCore.NarrativeGen
             {
                 var button = Instantiate(ChoiceButtonPrefab, ChoicesRoot);
                 button.gameObject.name = $"Choice_{choice.Id}";
-                if (button.TryGetComponentInChildren(out Text text))
+                if (button.TryGetComponentInChildren(out TextMeshProUGUI text))
                 {
                     text.text = choice.Text;
                 }

--- a/packages/sdk-unity/Runtime/VastCore.NarrativeGen.asmdef
+++ b/packages/sdk-unity/Runtime/VastCore.NarrativeGen.asmdef
@@ -1,7 +1,9 @@
 {
   "name": "VastCore.NarrativeGen",
   "rootNamespace": "VastCore.NarrativeGen",
-  "references": [],
+  "references": [
+    "Unity.TextMeshPro"
+  ],
   "includePlatforms": [],
   "excludePlatforms": [],
   "allowUnsafeCode": false,


### PR DESCRIPTION
## Summary
- add Unity.TextMeshPro reference to VastCore.NarrativeGen asmdef
- update MinimalNarrativeController and sample generator to use TextMeshProUGUI

## Testing
- dotnet test Packages/tests/NarrativeGen.Tests/NarrativeGen.Tests.csproj
