### PR TITLE
fix: force no-wrap for sample TMP labels

### DIFF
--- a/packages/sdk-unity/Editor/SamplesMenu.cs
+++ b/packages/sdk-unity/Editor/SamplesMenu.cs
@@ -132,6 +132,7 @@ namespace NarrativeGen.Editor
             text.fontSize = 24;
             text.alignment = TextAlignmentOptions.Midline;
             text.color = Color.white;
+            text.textWrappingMode = TextWrappingModes.NoWrap;
             text.text = "状態: 初期化待ち";
 
             return text;


### PR DESCRIPTION
## Summary
- ensure SamplesMenu scene generation sets StatusText and StateText textWrappingMode to NoWrap
- prevent unexpected line wrapping in generated sample UI

## Testing
- dotnet test Packages/tests/NarrativeGen.Tests/NarrativeGen.Tests.csproj

Closes #35