### PR TITLE
fix: disable wrapping on choice button labels

### DIFF
--- a/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
+++ b/packages/sdk-unity/Runtime/MinimalNarrativeController.cs
@@ -103,6 +103,7 @@ namespace NarrativeGen
                 var text = button.GetComponentInChildren<TextMeshProUGUI>();
                 if (text != null)
                 {
+                    text.textWrappingMode = TextWrappingModes.NoWrap;
                     if (choice.Outcome != null)
                     {
                         text.text = $"{choice.Text}\n<size=16><color=#FFD966>{choice.Outcome.Type}: {choice.Outcome.Value}</color></size>";


### PR DESCRIPTION
## Summary
- set TextMeshProUGUI.textWrappingMode = TextWrappingModes.NoWrap on dynamically created choice buttons
- align runtime button labels with editor-generated samples

## Testing
- dotnet test Packages/tests/NarrativeGen.Tests/NarrativeGen.Tests.csproj

Closes #37