### PR TITLE
feat: update web tester for choice execution

### DIFF
--- a/apps/web-tester/index.html
+++ b/apps/web-tester/index.html
@@ -63,11 +63,12 @@
 
       <div class="controls">
         <button id="startBtn">セッション開始</button>
-        <input id="itemInput" type="text" placeholder="アイテムID (例: mac_burger_001)" />
-        <button id="addItemBtn" disabled>アイテム追加</button>
       </div>
 
       <p id="statusText">初期化中...</p>
+
+      <div id="choices"></div>
+
       <pre id="stateView">{ "status": "初期化待ち" }</pre>
     </div>
 

--- a/apps/web-tester/main.js
+++ b/apps/web-tester/main.js
@@ -34,8 +34,7 @@ const entities = [
 ]
 
 const startBtn = document.getElementById('startBtn')
-const addItemBtn = document.getElementById('addItemBtn')
-const itemInput = document.getElementById('itemInput')
+const choicesContainer = document.getElementById('choices')
 const stateView = document.getElementById('stateView')
 const statusText = document.getElementById('statusText')
 
@@ -63,44 +62,66 @@ function setStatus(message, type = 'info') {
   statusText.dataset.type = type
 }
 
+function renderChoices() {
+  choicesContainer.innerHTML = ''
+
+  if (!session) {
+    const info = document.createElement('p')
+    info.textContent = 'セッションを開始すると選択肢が表示されます'
+    choicesContainer.appendChild(info)
+    return
+  }
+
+  const choices = session.getAvailableChoices()
+  if (!choices || choices.length === 0) {
+    const empty = document.createElement('p')
+    empty.textContent = '利用可能な選択肢はありません'
+    choicesContainer.appendChild(empty)
+    return
+  }
+
+  const list = document.createElement('div')
+  list.style.display = 'flex'
+  list.style.flexDirection = 'column'
+  list.style.gap = '0.5rem'
+
+  choices.forEach((choice) => {
+    const button = document.createElement('button')
+    button.textContent = formatChoiceLabel(choice)
+    button.addEventListener('click', () => {
+      try {
+        session.applyChoice(choice.id)
+        setStatus(`選択肢「${choice.text}」を適用しました`, 'success')
+      } catch (err) {
+        console.error(err)
+        setStatus(`選択肢の適用に失敗しました: ${err?.message ?? err}`, 'warn')
+      }
+      renderState()
+      renderChoices()
+    })
+    list.appendChild(button)
+  })
+
+  choicesContainer.appendChild(list)
+}
+
+function formatChoiceLabel(choice) {
+  if (choice?.outcome) {
+    return `${choice.text} (${choice.outcome.type}: ${choice.outcome.value})`
+  }
+  return choice?.text ?? '(不明な選択肢)'
+}
+
 startBtn.addEventListener('click', () => {
   session = new GameSession(model, {
     entities,
     initialInventory: [],
   })
   setStatus('セッションを開始しました', 'success')
-  addItemBtn.disabled = false
   renderState()
-})
-
-addItemBtn.addEventListener('click', () => {
-  if (!session) {
-    setStatus('セッションを開始してください', 'warn')
-    return
-  }
-
-  const id = itemInput.value.trim()
-  if (!id) {
-    setStatus('アイテムIDを入力してください', 'warn')
-    return
-  }
-
-  const entity = session.pickupEntity(id)
-  if (!entity) {
-    setStatus(`アイテム「${id}」は存在しません`, 'warn')
-    return
-  }
-
-  setStatus(`アイテム「${entity.id}」を追加しました`, 'success')
-  renderState()
-  itemInput.value = ''
-})
-
-itemInput.addEventListener('keydown', (event) => {
-  if (event.key === 'Enter') {
-    addItemBtn.click()
-  }
+  renderChoices()
 })
 
 setStatus('「セッション開始」を押して操作を始めてください')
 renderState()
+renderChoices()


### PR DESCRIPTION
## Summary
- remove manual item editing controls from the tester UI
- render GameSession choices as buttons and call applyChoice on click
- refresh status and state views after each interaction

## Testing
- npm install
- npm run build

Closes #42