### PR TITLE
fix: resolve nullable warnings in Inventory.cs

### DIFF
--- a/packages/sdk-unity/Runtime/Inventory.cs
+++ b/packages/sdk-unity/Runtime/Inventory.cs
@@ -111,9 +111,9 @@ namespace NarrativeGen
             return new List<string>(items);
         }
 
-        private static string NormalizeId(string id)
+        private static string NormalizeId(string? id)
         {
-            return id.Trim().ToLowerInvariant();
+            return id?.Trim().ToLowerInvariant() ?? string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fix nullable warnings in Inventory.cs by updating NormalizeId method.